### PR TITLE
Correct PHP version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1"
+        "php": "^7.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
`>=7.1` is quite a dangerous constraint as it is a non-bounded one (it would allow PHP 8+ as well). While it's ok to not have large platform boundaries, e.g. `^7.1` instead of `~7.1 || ~7.2` for most projects, I would recommend to avoid cross major versions.